### PR TITLE
Exposed percision settings

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -21,6 +21,7 @@ module SassC
 
       Native.option_set_is_indented_syntax_src(native_options, true) if sass?
       Native.option_set_input_path(native_options, filename) if filename
+      Native.option_set_precision(native_options, precision) if precision
       Native.option_set_include_path(native_options, load_paths)
       Native.option_set_output_style(native_options, output_style_enum)
       Native.option_set_source_comments(native_options, true) if line_comments?
@@ -62,6 +63,10 @@ module SassC
 
     def filename
       @options[:filename]
+    end
+
+    def precision
+      @options[:precision]
     end
 
     def sass?

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -64,6 +64,34 @@ foo {
 SCSS
     end
 
+    def test_precision
+      template = <<-SCSS
+$var: 1;
+.foo {
+  baz: $var / 3; }
+SCSS
+      expected_output = <<-CSS
+.foo {
+  baz: 0.33333333; }
+CSS
+      output = Engine.new(template, precision: 8).render
+      assert_equal expected_output, output
+    end
+
+    def test_precision_not_specified
+      template = <<-SCSS
+$var: 1;
+.foo {
+  baz: $var / 3; }
+SCSS
+      expected_output = <<-CSS
+.foo {
+  baz: 0.33333; }
+CSS
+      output = Engine.new(template).render
+      assert_equal expected_output, output
+    end
+
     def test_dependency_filenames_are_reported
       temp_file("not_included.scss", "$size: 30px;")
       temp_file("import_parent.scss", "$size: 30px;")


### PR DESCRIPTION
We are moving from the sass gem to sassc-ruby gem and found precision setting was missing from the API binding.

Our use case needs this to keep the output consistent.