### PR TITLE
update to libsass 3.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This gem combines the speed of `libsass`, the [Sass C implementation](https://gi
 
 ### libsass Version
 
-[3.3.1](https://github.com/sass/libsass/releases/tag/3.3.1)
+[3.3.2](https://github.com/sass/libsass/releases/tag/3.3.2)
 
 ## Usage
 
@@ -25,6 +25,8 @@ and [awesome contributors](https://github.com/bolandrm/sassc-ruby/graphs/contrib
 
 ## Changelog
 
+- **1.8.2**
+  - Update to Libsass 3.3.2
 - **1.8.1**
   - Update to Libsass 3.3.1
 - **1.8.0**

--- a/lib/sassc/version.rb
+++ b/lib/sassc/version.rb
@@ -1,3 +1,3 @@
 module SassC
-  VERSION = "1.8.1"
+  VERSION = "1.8.2"
 end

--- a/lib/tasks/libsass.rb
+++ b/lib/tasks/libsass.rb
@@ -17,6 +17,6 @@ namespace :libsass do
   end
 
   file "lib/libsass.so" => "Makefile" do
-    sh 'make lib/libsass.so LDFLAGS="-Wall -O2"'
+    sh 'make lib/libsass.so'
   end
 end

--- a/test/custom_importer_test.rb
+++ b/test/custom_importer_test.rb
@@ -58,6 +58,8 @@ CSS
     end
 
     def test_dependency_list
+      base = temp_dir("").to_s
+
       temp_dir("fonts")
       temp_dir("fonts/sub")
       temp_file("fonts/sub/sub_fonts.scss", "$font: arial;")
@@ -78,13 +80,13 @@ SCSS
       })
       engine.render
 
-      dependencies = engine.dependencies.map(&:filename)
+      dependencies = engine.dependencies.map(&:filename).map { |f| f.gsub(base, "") }
 
       assert_equal [
+        "/fonts/sub/sub_fonts.scss",
+        "/styles2.scss",
         "fonts/fonts.scss",
-        "fonts/sub/sub_fonts.scss",
-        "styles1.scss",
-        "styles2.scss"
+        "styles1.scss"
       ], dependencies
     end
 

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -93,6 +93,8 @@ CSS
     end
 
     def test_dependency_filenames_are_reported
+      base = temp_dir("").to_s
+
       temp_file("not_included.scss", "$size: 30px;")
       temp_file("import_parent.scss", "$size: 30px;")
       temp_file("import.scss", "@import 'import_parent'; $size: 30px;")
@@ -102,9 +104,9 @@ CSS
       engine.render
       deps = engine.dependencies
 
-      expected = ["import.scss", "import_parent.scss"]
-      assert_equal expected, deps.map { |dep| dep.options[:filename] }.sort
-      assert_equal expected, deps.map(&:filename).sort
+      expected = ["/import.scss", "/import_parent.scss"]
+      assert_equal expected, deps.map { |dep| dep.options[:filename].gsub(base, "") }.sort
+      assert_equal expected, deps.map { |dep| dep.filename.gsub(base, "") }.sort
     end
 
     def test_no_dependencies

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -1,5 +1,6 @@
 require_relative "test_helper"
 require "stringio"
+require "sass/script"
 
 module SassC
   class FunctionsTest < MiniTest::Test

--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -9,7 +9,7 @@ module SassC
 
     class General < MiniTest::Test
       def test_it_reports_the_libsass_version
-        assert_equal "3.3.1", Native.version
+        assert_equal "3.3.2", Native.version
       end
     end
 


### PR DESCRIPTION
Hello, I wanted to bump libsass to 3.3.2. I thought it might have a fix for an issue we're having (https://github.com/sass/libsass/issues/1097#issuecomment-164043059) but it didn't after all. Oh well. Thank you!!