### PR TITLE
Switch easy to ease in order to use english idiom

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Use `libsass` with Ruby!
 
-This gem combines the speed of `libsass`, the [Sass C implementation](https://github.com/sass/libsass), with the easy of use of the original [Ruby Sass](https://github.com/sass/sass) library.
+This gem combines the speed of `libsass`, the [Sass C implementation](https://github.com/sass/libsass), with the ease of use of the original [Ruby Sass](https://github.com/sass/sass) library.
 
 ### libsass Version
 


### PR DESCRIPTION
Just a small change to the README, where a common English idiom was off by one letter.