### PR TITLE
Don't raise error when template is empty

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -17,6 +17,8 @@ module SassC
     end
 
     def render
+      return @template if @template.empty?
+
       data_context = Native.make_data_context(@template)
       context = Native.data_context_get_context(data_context)
       native_options = Native.context_get_options(context)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -189,5 +189,10 @@ CSS
       assert_match /sourceMappingURL/, output
       assert_match /.foo/, output
     end
+
+    def test_empty_template
+      output = Engine.new('').render
+      assert_equal '', output
+    end
   end
 end


### PR DESCRIPTION
sassc raises an error when an empty template is passed (see https://github.com/sass/libsass/blob/b2a3d98ed384d2d19aa79157d08fa21c3e8043e0/src/sass_context.cpp#L390). rubysass accepts that however, that means the sass and sassc gems behave differently when passed the same input:

```ruby
Sass::Engine.new('', style: :compressed).render # => ""
SassC::Engine.new('', style: :compressed).render # raises SassC::SyntaxError
# but with one space:
SassC::Engine.new(' ', style: :compressed).render # => ""
```

This change just short-circuits the whole `Engine#render`-method if the template is empty. This is the easiest solution I could see, but maybe I'm missing something.

A side note: While putting this together I noticed that the `:quiet`-option seems badly named, as it is more like a dry run if I understand it correctly. The quiet option in rubysass actually [surpresses warnings](http://sass-lang.com/documentation/file.SASS_REFERENCE.html), whule the sassc version just does not return the resulting css. This subtle difference might trip someone up. If the current behavior of the quiet option is indeed intentional, then this PR needs to be updated to make the behavior the same for the empty template case.