### PR TITLE
Show sass file on the top of backtrace

### DIFF
--- a/lib/sassc/error.rb
+++ b/lib/sassc/error.rb
@@ -11,6 +11,8 @@ module SassC
   # it's important to provide filename and line number information.
   # This will be used in various error reports to users, including backtraces;
   class SyntaxError < BaseError
+    LINE_INFO_REGEX = /on line (\d+) of (.+)/
+
     def backtrace
       return nil if super.nil?
       sass_backtrace + super
@@ -18,10 +20,10 @@ module SassC
 
     # The backtrace of the error within Sass files.
     def sass_backtrace
-      line_info = message.split("\n")[1]
+      line_info = message.split("\n").find { |line| line.match(LINE_INFO_REGEX) }
       return [] unless line_info
 
-      _, line, filename = line_info.match(/on line (\d+) of (.+)/).to_a
+      _, line, filename = line_info.match(LINE_INFO_REGEX).to_a
       ["#{Pathname.getwd.join(filename)}:#{line}"]
     end
   end

--- a/lib/sassc/error.rb
+++ b/lib/sassc/error.rb
@@ -1,9 +1,28 @@
+require 'pathname'
 require 'sass/error'
 
 module SassC
   class BaseError < StandardError; end
-  class SyntaxError < BaseError; end
   class NotRenderedError < BaseError; end
   class InvalidStyleError < BaseError; end
   class UnsupportedValue < BaseError; end
+
+  # When dealing with SyntaxErrors,
+  # it's important to provide filename and line number information.
+  # This will be used in various error reports to users, including backtraces;
+  class SyntaxError < BaseError
+    def backtrace
+      return nil if super.nil?
+      sass_backtrace + super
+    end
+
+    # The backtrace of the error within Sass files.
+    def sass_backtrace
+      line_info = message.split("\n")[1]
+      return [] unless line_info
+
+      _, line, filename = line_info.match(/on line (\d+) of (.+)/).to_a
+      ["#{Pathname.getwd.join(filename)}:#{line}"]
+    end
+  end
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -1,0 +1,22 @@
+require_relative "test_helper"
+
+module SassC
+  class ErrorTest < MiniTest::Test
+    def test_first_backtrace_is_sass
+      line     = 2
+      filename = "app/assets/stylesheets/application.scss"
+
+      begin
+        raise SassC::SyntaxError.new(<<-ERROR)
+Error: property "padding" must be followed by a ':'
+        on line #{line} of #{filename}
+>>   padding top: 10px;
+   --^
+        ERROR
+      rescue SassC::SyntaxError => err
+        expected = "#{Pathname.getwd.join(filename)}:#{line}"
+        assert_equal expected, err.backtrace.first
+      end
+    end
+  end
+end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -17,6 +17,21 @@ Error: property "padding" must be followed by a ':'
         expected = "#{Pathname.getwd.join(filename)}:#{line}"
         assert_equal expected, err.backtrace.first
       end
+
+      begin
+        raise SassC::SyntaxError.new(<<-ERROR)
+Error: no mixin named border-radius
+
+       Backtrace:
+       \t#{filename}:#{line}
+        on line #{line} of #{filename}
+>>     @include border-radius(5px);
+   -------------^
+        ERROR
+      rescue SassC::SyntaxError => err
+        expected = "#{Pathname.getwd.join(filename)}:#{line}"
+        assert_equal expected, err.backtrace.first
+      end
     end
   end
 end


### PR DESCRIPTION
When SyntaxError is raised, I want to see the broken sass file on error page. This is implemented in `Sass::SyntaxError` too.
Since we can know filename and lineno only from message, I implemented it by parsing it. 

## Screen shot
### before
![2016-01-15 18 50 26](https://cloud.githubusercontent.com/assets/3138447/12350219/1812c914-bbb9-11e5-8503-0913f15edcbd.png)

### after
![2016-01-15 18 50 57](https://cloud.githubusercontent.com/assets/3138447/12350222/19daf924-bbb9-11e5-9e84-1ba2fbb6866a.png)
