### PR TITLE
Support ${MAKE} env variables and default value for mswin/bsd/solaris.

### DIFF
--- a/lib/tasks/libsass.rb
+++ b/lib/tasks/libsass.rb
@@ -17,6 +17,15 @@ namespace :libsass do
   end
 
   file "lib/libsass.so" => "Makefile" do
-    sh 'make lib/libsass.so'
+    make_program = ENV['MAKE']
+    make_program ||= case RUBY_PLATFORM
+                     when /mswin/
+                       'nmake'
+                     when /(bsd|solaris)/
+                       'gmake'
+                     else
+                       'make'
+                     end
+    sh "#{make_program} lib/libsass.so"
   end
 end


### PR DESCRIPTION
Like as redis/hiredis-rb@a5d7248dc886af7fa06b3a51c36071261b156963 commit, I'd like to be supported gmake on *BSD platform.

This patch includes standard ENV['MAKE'] variable to override manually and mswin nmake support (latter is untested).