### PR TITLE
Changes for frozen string literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.0
+  - 2.3.0
 notifications:
   email: false

--- a/lib/sassc.rb
+++ b/lib/sassc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
 end
 

--- a/lib/sassc/cache_stores.rb
+++ b/lib/sassc/cache_stores.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module CacheStores
   end

--- a/lib/sassc/cache_stores/base.rb
+++ b/lib/sassc/cache_stores/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module CacheStores
     class Base

--- a/lib/sassc/dependency.rb
+++ b/lib/sassc/dependency.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   class Dependency
     attr_reader :filename

--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "error"
 
 module SassC

--- a/lib/sassc/error.rb
+++ b/lib/sassc/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'sass/error'
 
 module SassC

--- a/lib/sassc/functions_handler.rb
+++ b/lib/sassc/functions_handler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   class FunctionsHandler
     def initialize(options)

--- a/lib/sassc/import_handler.rb
+++ b/lib/sassc/import_handler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   class ImportHandler
     def initialize(options)

--- a/lib/sassc/importer.rb
+++ b/lib/sassc/importer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   class Importer
     attr_reader :options

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "ffi"
 
 module SassC
@@ -49,9 +50,15 @@ module SassC
 
     def self.native_string(string)
       string = string.to_s
-      string << "\0"
-      data = Native::LibC.malloc(string.bytesize)
+      string_size = string.bytesize
+
+      terminator = String.new.force_encoding(string.encoding) << "\0"
+
+      data = Native::LibC.malloc(string_size + terminator.bytesize)
+
       data.write_string(string)
+      (data+string_size).write_string(terminator)
+
       data
     end
 

--- a/lib/sassc/native/lib_c.rb
+++ b/lib/sassc/native/lib_c.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     module LibC

--- a/lib/sassc/native/native_context_api.rb
+++ b/lib/sassc/native/native_context_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     attach_function :version, :libsass_version, [], :string

--- a/lib/sassc/native/native_functions_api.rb
+++ b/lib/sassc/native/native_functions_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     # Creators for sass function list and function descriptors

--- a/lib/sassc/native/sass2scss_api.rb
+++ b/lib/sassc/native/sass2scss_api.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     # ADDAPI char* ADDCALL sass2scss (const char* sass, const int options);

--- a/lib/sassc/native/sass_input_style.rb
+++ b/lib/sassc/native/sass_input_style.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     SassInputStyle = enum(

--- a/lib/sassc/native/sass_output_style.rb
+++ b/lib/sassc/native/sass_output_style.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     SassOutputStyle = enum(

--- a/lib/sassc/native/sass_value.rb
+++ b/lib/sassc/native/sass_value.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     class SassValue < FFI::Union; end

--- a/lib/sassc/native/string_list.rb
+++ b/lib/sassc/native/string_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Native
     class StringList < FFI::Struct

--- a/lib/sassc/sass_2_scss.rb
+++ b/lib/sassc/sass_2_scss.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   class Sass2Scss
     def self.convert(sass)

--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     def self.custom_functions

--- a/lib/sassc/script/functions.rb
+++ b/lib/sassc/script/functions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module Functions

--- a/lib/sassc/script/value_conversion.rb
+++ b/lib/sassc/script/value_conversion.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/script/value_conversion/base.rb
+++ b/lib/sassc/script/value_conversion/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/script/value_conversion/color.rb
+++ b/lib/sassc/script/value_conversion/color.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/script/value_conversion/map.rb
+++ b/lib/sassc/script/value_conversion/map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/script/value_conversion/number.rb
+++ b/lib/sassc/script/value_conversion/number.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/script/value_conversion/string.rb
+++ b/lib/sassc/script/value_conversion/string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   module Script
     module ValueConversion

--- a/lib/sassc/version.rb
+++ b/lib/sassc/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SassC
   VERSION = "1.8.4"
 end

--- a/lib/tasks/libsass.rb
+++ b/lib/tasks/libsass.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :libsass do
   desc "Compile libsass"
   task :compile do

--- a/test/custom_importer_test.rb
+++ b/test/custom_importer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 module SassC

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 module SassC
@@ -163,7 +164,7 @@ CSS
     end
 
     def test_encoding_matches_input
-      input = "$size: 30px;"
+      input = String.new("$size: 30px;")
       input.force_encoding("UTF-8")
       output = Engine.new(input).render
       assert_equal input.encoding, output.encoding
@@ -202,7 +203,7 @@ CSS
     end
 
     def test_empty_template_encoding_matches_input
-      input = ''.force_encoding("ISO-8859-1")
+      input = String.new('').force_encoding("ISO-8859-1")
       output = Engine.new(input).render
       assert_equal input.encoding, output.encoding
     end

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 require "stringio"
 require "sass/script"

--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 module SassC

--- a/test/output_style_test.rb
+++ b/test/output_style_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 module SassC

--- a/test/sass_2_scss_test.rb
+++ b/test/sass_2_scss_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "test_helper"
 
 module SassC

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "minitest/autorun"
 require "minitest/pride"
 require "minitest/around/unit"


### PR DESCRIPTION
User frozen string literals on ruby 2.3.0+
