### PR TITLE
Add omit_source_map_url option

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -32,6 +32,7 @@ module SassC
       Native.option_set_source_map_file(native_options, source_map_file) if source_map_file
       Native.option_set_source_map_embed(native_options, true) if source_map_embed?
       Native.option_set_source_map_contents(native_options, true) if source_map_contents?
+      Native.option_set_omit_source_map_url(native_options, true) if omit_source_map_url?
 
       import_handler.setup(native_options)
       functions_handler.setup(native_options)
@@ -96,6 +97,10 @@ module SassC
 
     def source_map_contents?
       @options[:source_map_contents]
+    end
+
+    def omit_source_map_url?
+      @options[:omit_source_map_url]
     end
 
     def source_map_file

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -166,6 +166,22 @@ MAP
       assert_raises(NotRenderedError) { engine.source_map }
     end
 
+    def test_omit_source_map_url
+      temp_file('style.scss', <<SCSS)
+p {
+  padding: 20px;
+}
+SCSS
+      engine = Engine.new(File.read('style.scss'), {
+        source_map_file: "style.scss.map",
+        source_map_contents: true,
+        omit_source_map_url: true
+      })
+      output = engine.render
+
+      refute_match /sourceMappingURL/, output
+    end
+
     def test_load_paths
       temp_dir("included_1")
       temp_dir("included_2")


### PR DESCRIPTION
Adds support for the `omit_source_map_url` option w/ test. 

Useful when sassc engine is part of a pipeline and the generated map isn't final. e.g. sassc => autoprefixer.