### PR TITLE
bundler is a development dependency

### DIFF
--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "test_construct"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "bundler"
 
-  spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
   spec.add_dependency "sass", ">= 3.3.0"
 


### PR DESCRIPTION
bundler is moved as dependency by 6458ff12.
However it seems bundler is used for only development for now.
