### PR TITLE
Refactor gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,4 @@
-begin
-  require 'bundler/gem_tasks'
-rescue LoadError
-  puts 'Cannot load bundler/gem_tasks'
-end
-
+require 'bundler/gem_tasks'
 require 'tasks/libsass'
 
 task default: :test

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -21,13 +21,13 @@ Gem::Specification.new do |spec|
 
   spec.extensions    = ["ext/Rakefile"]
 
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "test_construct"
   spec.add_development_dependency "pry"
 
-  spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
   spec.add_dependency "sass", ">= 3.3.0"
 
@@ -43,4 +43,3 @@ Gem::Specification.new do |spec|
     end
   end
 end
-

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sass/sassc-ruby"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = Dir.glob('lib/**/*') + %w(README.md LICENSE.txt ext/Rakefile)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
- Removes runtime dependency on bundler - the only place that requires bundler seems to be in the Rakefile
- Assume that bundler is available in the Rakefile, if not Ruby's normal error handling should make it clear how to solve the problem
- Don't package test files into the package uploaded to rubygems