### PR TITLE
bump libsass to version 3.4.1

### DIFF
--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -9,7 +9,7 @@ module SassC
 
     class General < MiniTest::Test
       def test_it_reports_the_libsass_version
-        assert_equal "3.4.0", Native.version
+        assert_equal "3.4.1", Native.version
       end
     end
 


### PR DESCRIPTION
@bolandrm sorry to bother, a patch has already been released to libsass. Would you mind also bumping this library?
Thanks!