### PR TITLE
Change rake to a runtime dependency from a development dependency

### DIFF
--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
 
   spec.extensions    = ["ext/Rakefile"]
 
-  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "test_construct"
   spec.add_development_dependency "pry"
 
+  spec.add_dependency "rake"
   spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
   spec.add_dependency "sass", ">= 3.3.0"


### PR DESCRIPTION
Hi @bolandrm , we have a gem that depends on SassC, one of our end-users was unable to install it. The fix was `gem install rake`. This crops up in the default `ruby` package in the Ubuntu repos, which supplies a `rake` executable in `/usr/bin/` but does not include the gem.

This change makes sense to me since libsass is compiled in a Rake task.