### PR TITLE
bundler is a development dependency only

### DIFF
--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "test_construct"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "bundler"
 
-  spec.add_dependency "bundler"
   spec.add_dependency "ffi", "~> 1.9.6"
   spec.add_dependency "sass", ">= 3.3.0"
 


### PR DESCRIPTION
Make bundler a development dependency because it is only used for rake
tasks and travis CI, but not at runtime.