### PR TITLE
Require Sass::Deprecation module

### DIFF
--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -28,6 +28,7 @@ module Sass
 end
 
 require 'sass/util'
+require 'sass/deprecation'
 require 'sass/script/value/base'
 require 'sass/script/value/string'
 require 'sass/script/value/color'


### PR DESCRIPTION
Hi there!

I was developing a rails application using the `sassc-rails` gem and I got an error like this:

`NameError: uninitialized constant Sass::Deprecation`

Then I realized that this gem was including the latest version of `sass` and it is requiring the modules individually in the `lib/sassc/script.rb` file.

I am not sure if this fix belongs here or the `require` is missing in some `sass` file.

Thoughts?