### PR TITLE
Fix NameError: uninitialized constant Sass::Deprecation error

### DIFF
--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -28,6 +28,7 @@ module Sass
 end
 
 require 'sass/util'
+require 'sass/deprecation'
 require 'sass/script/value/base'
 require 'sass/script/value/string'
 require 'sass/script/value/color'


### PR DESCRIPTION
Due to a change in `v3.4.25` of the `sass` gem, this project began
throwing an unitialized constant NameError. Explicitly requiring
`sass/deprecation` solves the issue.

Resolves #69