### PR TITLE
Add script value map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
   - 2.2.0
   - 2.3.3
   - 2.4.0
+  - 2.5.0
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This gem is maintained by [Ryan Boland](https://ryanboland.com)
 and [awesome contributors](https://github.com/bolandrm/sassc-ruby/graphs/contributors).
 
 ## Changelog
+- **1.11.5**
+  - Add `Value::Map`
 - **1.11.4**
   - Fix `Value::List` related issue with sass 3.5.0
 - **1.11.3**

--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -38,6 +38,7 @@ require 'sass/script/value/base'
 require 'sass/script/value/string'
 require 'sass/script/value/color'
 require 'sass/script/value/bool'
+require 'sass/script/value/map'
 
 SassC::Script::String = Sass::Script::Value::String
 SassC::Script::Value::String = Sass::Script::Value::String
@@ -47,3 +48,6 @@ SassC::Script::Value::Color = Sass::Script::Value::Color
 
 SassC::Script::Bool = Sass::Script::Value::Bool
 SassC::Script::Value::Bool = Sass::Script::Value::Bool
+
+SassC::Script::Map = Sass::Script::Value::Map
+SassC::Script::Value::Map = Sass::Script::Value::Map

--- a/lib/sassc/version.rb
+++ b/lib/sassc/version.rb
@@ -1,3 +1,3 @@
 module SassC
-  VERSION = "1.11.4"
+  VERSION = "1.11.5"
 end


### PR DESCRIPTION
When I converted the values we had defined as `Sass::Script::Value::` to `SassC::Script::Value::` I noticed that there was no `SassC::Script::Value::Map` available. This MR adds it.

Also, a test for ruby 2.5.0 has been added.