### PR TITLE
Update libsass to latest version of 3.5.4

### DIFF
--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -9,7 +9,7 @@ module SassC
 
     class General < MiniTest::Test
       def test_it_reports_the_libsass_version
-        assert_equal "3.5.4", Native.version
+        assert Native.version.start_with?("3.5.4")
       end
     end
 


### PR DESCRIPTION
This resolves #79 and fixes an issue where the latest SassC is unable to
`@import` files that end in a `.css` extension. By pulling in the latest
changes of libsass at branch '3-5-stable', the breaking change that
caused this issue will be reverted and life goes back to normal.

shoutouts to @jakeberesford and @mttdffy for helping test this out.