### PR TITLE
Downgrade to libsass 3.5.2 to fix css imports

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -267,5 +267,16 @@ CSS
       output = Engine.new(input).render
       assert_equal input.encoding, output.encoding
     end
+
+    def test_import_plain_css
+      temp_file("test.css", ".something{color: red}")
+      expected_output = <<-CSS
+.something {
+  color: red; }
+      CSS
+
+      output = Engine.new("@import 'test'").render
+      assert_equal expected_output, output
+    end
   end
 end

--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -9,7 +9,7 @@ module SassC
 
     class General < MiniTest::Test
       def test_it_reports_the_libsass_version
-        assert_equal "3.5.4", Native.version
+        assert_equal "3.5.2", Native.version
       end
     end
 


### PR DESCRIPTION
This is an alternative to #80 to fix #79. I tried upgrading to the latest commit in 3.5-stable, but I couldn't compile the thing locally. It might be an issue with my enviroment though.