### PR TITLE
New option "output_path" added.

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -25,6 +25,7 @@ module SassC
 
       Native.option_set_is_indented_syntax_src(native_options, true) if sass?
       Native.option_set_input_path(native_options, filename) if filename
+      Native.option_set_output_path(native_options, output_path) if output_path
       Native.option_set_precision(native_options, precision) if precision
       Native.option_set_include_path(native_options, load_paths)
       Native.option_set_output_style(native_options, output_style_enum)
@@ -71,6 +72,10 @@ module SassC
 
     def filename
       @options[:filename]
+    end
+
+    def output_path
+      @options[:output_path]
     end
 
     private

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -160,6 +160,57 @@ SCSS
 MAP
     end
 
+    def test_source_map_filenames
+      temp_dir('admin')
+
+      temp_file('admin/text-color.scss', <<SCSS)
+p {
+  color: red;
+}
+SCSS
+      temp_file('style.scss', <<SCSS)
+@import 'admin/text-color';
+
+p {
+  padding: 20px;
+}
+SCSS
+      engine = Engine.new(File.read('style.scss'), {
+          source_map_file: "output-style.css.map",
+          filename: "input-style.scss",
+          output_path: "output-style.css",
+          source_map_contents: true
+      })
+
+      assert_equal <<CSS.strip, engine.render
+p {
+  color: red; }
+
+p {
+  padding: 20px; }
+
+/*# sourceMappingURL=output-style.css.map */
+CSS
+
+
+      assert_equal <<MAP.strip, engine.source_map
+{
+\t"version": 3,
+\t"file": "output-style.css",
+\t"sources": [
+\t\t"input-style.scss",
+\t\t"admin/text-color.scss"
+\t],
+\t"sourcesContent": [
+\t\t"@import 'admin/text-color';\\n\\np {\\n  padding: 20px;\\n}\\n",
+\t\t"p {\\n  color: red;\\n}\\n"
+\t],
+\t"names": [],
+\t"mappings": "ACAA,AAAA,CAAC,CAAC;EACA,KAAK,EAAE,GAAG,GACX;;ADAD,AAAA,CAAC,CAAC;EACA,OAAO,EAAE,IAAI,GACd"
+}
+MAP
+    end
+
     def test_no_source_map
       engine = Engine.new("$size: 30px;")
       engine.render


### PR DESCRIPTION
The native library has a function `sass_option_set_output_path` which is attached to ruby in `native_context_api.rb`. But in `engine.rb` this option is not set (why?).
However to produce correct source maps, the _output path_ must be known to the native library.

The use of the parameters `:source_map_file`, `:filename` and `:output_path` is shown in the `test_source_map_filenames` test in file `test/engine_test.rb`.

By the way, all these parameters need to be documented. Where is the right place to put this?