### PR TITLE
Update libsass to 3.5.5

### DIFF
--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -11,7 +11,7 @@ module SassC
 
     class General < MiniTest::Test
       def test_it_reports_the_libsass_version
-        assert_equal "3.5.2", Native.version
+        assert_equal "3.5.5", Native.version
       end
     end
 


### PR DESCRIPTION
The import change that broke version 3.5.4 was reverted in 3.5.5

There is nothing in there that sticks out, but having the ruby version in sync with the library sounds like a good idea to me. I was looking for something else, so feel free to drop it if there are other plans.