### PR TITLE
Support ancient obsolete Rubies (v2.0.0+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ language: ruby
 bundler_args: "--binstubs --standalone --without documentation --path ../bundle"
 script: "bundle exec rake test"
 rvm:
+  - 2.0.0
+  - 2.1.10
+  - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 notifications:
   email: false

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 
-  spec.required_ruby_version = ">= 2.3.3"
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
We won't provide precompiled versions for these Rubies, but we could still support them quite easily (minimal level of support, CI must pass but no manual testing).

Fixes #106