### PR TITLE
Reduce Ruby warnings

### DIFF
--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -42,7 +42,7 @@ module SassC
 
     # Remove the redundant "sass_" from the beginning of every method name
     def self.attach_function(*args)
-      super if args.size != 3
+      return super if args.size != 3
 
       if args[0] =~ /^sass_/
         args.unshift args[0].to_s.sub(/^sass_/, "")

--- a/lib/sassc/native/native_functions_api.rb
+++ b/lib/sassc/native/native_functions_api.rb
@@ -98,11 +98,6 @@ module SassC
       attach_function "sass_color_set_#{color_channel}".to_sym, [:sass_value_ptr, :double], :void
     end
 
-    # ADDAPI size_t ADDCALL sass_list_get_length(const union Sass_Value* v)
-    # ADDAPI union Sass_Value* ADDCALL sass_list_get_value (const union Sass_Value* v, size_t i);
-    attach_function :sass_list_get_length, [:sass_value_ptr], :size_t
-    attach_function :sass_list_get_value, [:sass_value_ptr, :size_t], :sass_value_ptr
-
     # ADDAPI char* ADDCALL sass_error_get_message (const union Sass_Value* v);
     # ADDAPI void ADDCALL sass_error_set_message (union Sass_Value* v, char* msg);
     attach_function :sass_error_get_message, [:sass_value_ptr], :string


### PR DESCRIPTION
Problem
===

sassc-ruby displays warnings on load the gem if `-w` options is passed to ruby interpreter.

```console
$ ruby -w -rsassc -e ''
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old version
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old version
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old _make_data_context
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old _make_data_context
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old _context_get_included_files
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old _context_get_included_files
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old list_get_length
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old list_get_length
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old list_get_value
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ffi-1.11.1/lib/ffi/library.rb:275:
warning: method redefined; discarding old list_get_value
```

This pull request suppresses the warnings.

Note
===

sassc-ruby has other warnings in test code, but this pull request does not suppress the warnings. Because they does not affect users.
If you'd like to see the warning, you can execute `rake test` with `RUBYOPT=-w` environment variable.