### PR TITLE
Link C/C++ stdlib statically for binary gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.gem
 mkmf.log
 vendor/bundle
+/ext/Makefile

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ Rake::ExtensionTask.new('libsass', gem_spec) do |ext|
   # Link C++ stdlib statically when building binary gems.
   ext.cross_config_options << '--enable-static-stdlib'
 
-  ext.cross_config_options << '--disable-march-native'
+  ext.cross_config_options << '--disable-march-tune-native'
 
   ext.cross_compiling do |spec|
     spec.files.reject! { |path| File.fnmatch?('ext/*', path) }

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,15 @@ task default: :test
 
 require 'rake/extensiontask'
 gem_spec = Gem::Specification.load("sassc.gemspec")
+
+# HACK: Prevent rake-compiler from overriding required_ruby_version,
+# because the shared library here is Ruby-agnostic.
+# See https://github.com/rake-compiler/rake-compiler/issues/153
+module FixRequiredRubyVersion
+  def required_ruby_version=(*); end
+end
+Gem::Specification.send(:prepend, FixRequiredRubyVersion)
+
 Rake::ExtensionTask.new('libsass', gem_spec) do |ext|
   ext.name = 'libsass'
   ext.ext_dir = 'ext'
@@ -18,11 +27,6 @@ Rake::ExtensionTask.new('libsass', gem_spec) do |ext|
 
   ext.cross_compiling do |spec|
     spec.files.reject! { |path| File.fnmatch?('ext/*', path) }
-
-
-    # Reset the required ruby version requirements.
-    # This is set by rake-compiler, but the shared library here is Ruby-agnostic.
-    spec.required_ruby_version = gem_spec.required_ruby_version
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ Rake::ExtensionTask.new('libsass', gem_spec) do |ext|
   # Link C++ stdlib statically when building binary gems.
   ext.cross_config_options << '--enable-static-stdlib'
 
+  ext.cross_config_options << '--disable-march-native'
+
   ext.cross_compiling do |spec|
     spec.files.reject! { |path| File.fnmatch?('ext/*', path) }
 

--- a/ext/depend
+++ b/ext/depend
@@ -1,0 +1,4 @@
+# Replaces default mkmf dependencies. Default mkmf dependencies include all libruby headers.
+# We don't need libruby and some of these headers are missing on JRuby (breaking compilation there).
+$(OBJS): $(HDRS)
+

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -70,13 +70,14 @@ $LIBRUBYARG = nil
 MakeMakefile.send(:remove_const, :EXPORT_PREFIX)
 MakeMakefile::EXPORT_PREFIX = nil
 
-if RUBY_PLATFORM == 'java'
-  # COUTFLAG is not set correctly on jruby
+if RUBY_ENGINE == 'jruby' &&
+   Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new('9.2.8.0')
+  # COUTFLAG is not set correctly on jruby<9.2.8.0
   # See https://github.com/jruby/jruby/issues/5749
   MakeMakefile.send(:remove_const, :COUTFLAG)
   MakeMakefile::COUTFLAG = '-o $(empty)'
 
-  # CCDLFLAGS is not set correctly on jruby
+  # CCDLFLAGS is not set correctly on jruby<9.2.8.0
   # See https://github.com/jruby/jruby/issues/5751
   $CXXFLAGS << ' -fPIC'
 end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -20,9 +20,9 @@ if enable_config('static-stdlib', false)
 end
 
 # Set to false when building binary gems
-if enable_config('march-native', true)
-  $CFLAGS << ' -march=native'
-  $CXXFLAGS << ' -march=native'
+if enable_config('march-tune-native', true)
+  $CFLAGS << ' -march=native -mtune=native'
+  $CXXFLAGS << ' -march=native -mtune=native'
 end
 
 if enable_config('lto', true)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,9 +14,21 @@ require 'mkmf'
 
 $CXXFLAGS << ' -std=c++11'
 
-# Link stdlib statically when building binary gems.
-if enable_config('static-stdlib')
+# Set to true when building binary gems
+if enable_config('static-stdlib', false)
   $LDFLAGS << ' -static-libgcc -static-libstdc++'
+end
+
+# Set to false when building binary gems
+if enable_config('march-native', true)
+  $CFLAGS << ' -march=native'
+  $CXXFLAGS << ' -march=native'
+end
+
+if enable_config('lto', true)
+  $CFLAGS << ' -flto'
+  $CXXFLAGS << ' -flto'
+  $LDFLAGS << ' -flto'
 end
 
 # Disable noisy compilation warnings.

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -9,7 +9,7 @@ module SassC
     spec = Gem.loaded_specs["sassc"]
     gem_root = spec.gem_dir
 
-    dl_ext = (RUBY_PLATFORM =~ /darwin/ ? 'bundle' : 'so')
+    dl_ext = (RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'bundle' : 'so')
     ffi_lib "#{gem_root}/lib/sassc/libsass.#{dl_ext}"
 
     require_relative "native/sass_value"

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -10,12 +10,7 @@ module SassC
     gem_root = spec.gem_dir
 
     dl_ext = (RUBY_PLATFORM =~ /darwin/ ? 'bundle' : 'so')
-    ruby_version_so_path = "#{gem_root}/lib/sassc/#{RUBY_VERSION[/\d+.\d+/]}/libsass.#{dl_ext}"
-    if File.exist?(ruby_version_so_path)
-      ffi_lib ruby_version_so_path
-    else
-      ffi_lib "#{gem_root}/lib/sassc/libsass.#{dl_ext}"
-    end
+    ffi_lib "#{gem_root}/lib/sassc/libsass.#{dl_ext}"
 
     require_relative "native/sass_value"
 

--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -6,11 +6,8 @@ module SassC
   module Native
     extend FFI::Library
 
-    spec = Gem.loaded_specs["sassc"]
-    gem_root = spec.gem_dir
-
     dl_ext = (RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'bundle' : 'so')
-    ffi_lib "#{gem_root}/lib/sassc/libsass.#{dl_ext}"
+    ffi_lib File.expand_path("libsass.#{dl_ext}", __dir__)
 
     require_relative "native/sass_value"
 

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -40,18 +40,30 @@ Gem::Specification.new do |spec|
   gem_dir = File.expand_path(File.dirname(__FILE__)) + "/"
 
   libsass_dir = File.join(gem_dir, 'ext', 'libsass')
-  if !File.directory?(libsass_dir)
-    $stderr.puts "Error: ext/libsass not checked out. Please run:\n\n"\
-                 "  git submodule update --init"
-    exit 1
+  if !File.directory?(libsass_dir) ||
+      # '.', '..', and possibly '.git' from a failed checkout:
+      Dir.entries(libsass_dir).size <= 3
+    Dir.chdir(__dir__) { system('git submodule update --init') } or
+        fail 'Could not fetch libsass'
+  end
+
+  # Write a VERSION file for non-binary gems (for `SassC::Native.version`).
+  if !File.exist?(File.join(libsass_dir, 'VERSION'))
+    libsass_version = Dir.chdir(libsass_dir) do
+      %x[git describe --abbrev=4 --dirty --always --tags].chomp
+    end
+    File.write(File.join(libsass_dir, 'VERSION'), libsass_version)
   end
 
   Dir.chdir(libsass_dir) do
     submodule_relative_path = File.join('ext', 'libsass')
+    skip_re = %r{(^("?test|docs|script)/)|\.md$|\.yml$}
+    only_re = %r{\.[ch](pp)?$}
     `git ls-files`.split($\).each do |filename|
-      next if filename =~ %r{(^("?test|docs|script)/)|\.md$|\.yml$}
+      next if filename =~ skip_re || filename !~ only_re
       spec.files << File.join(submodule_relative_path, filename)
     end
+    spec.files << File.join(submodule_relative_path, 'VERSION')
   end
 
 end


### PR DESCRIPTION
Also:
1. Compile via `mkmf` instead of libsass's own Makefile. This is necessary to make cross-compilation work (rake-compiler hooks into mkmf).
2. Do not use per-ruby versions of `libsass.so`. It is unnecessary, because `libsass.so` is Ruby-agnostic (the FFI gem is used instead to use it from any Ruby version).
3. Add VERSION file to the non-precompiled gem (as the git information is not available when installing).
4. Clean before every build.