### PR TITLE
extconf.rb: Always write VERSION if we have .git

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -38,13 +38,12 @@ $CFLAGS.gsub!(/[\s+](-ansi|-std=[^\s]+)/, '')
 dir_config 'libsass'
 
 libsass_version = Dir.chdir(libsass_dir) do
-  if File.exist?('VERSION')
-    File.read('VERSION').chomp
-  elsif File.exist?('.git')
+  if File.exist?('.git')
     ver = %x[git describe --abbrev=4 --dirty --always --tags].chomp
     File.write('VERSION', ver)
     ver
   end
+  File.read('VERSION').chomp if File.exist?('VERSION')
 end
 
 if libsass_version

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   end
 
   # Write a VERSION file for non-binary gems (for `SassC::Native.version`).
-  if !File.exist?(File.join(libsass_dir, 'VERSION'))
+  if File.exist?(File.join(libsass_dir, '.git'))
     libsass_version = Dir.chdir(libsass_dir) do
       %x[git describe --abbrev=4 --dirty --always --tags].chomp
     end


### PR DESCRIPTION
This ensures VERSION is updated when the repo is updated