### PR TITLE
thread safe function helpers

### DIFF
--- a/lib/sassc/functions_handler.rb
+++ b/lib/sassc/functions_handler.rb
@@ -12,7 +12,11 @@ module SassC
 
       list = Native.make_function_list(Script.custom_functions.count)
 
-      functions = FunctionWrapper.extend(Script::Functions)
+      # use an anonymous class wrapper to avoid mutations in a threaded environment
+      functions = Class.new do
+        attr_accessor :options
+        include Script::Functions
+      end.new
       functions.options = @options
 
       Script.custom_functions.each_with_index do |custom_function, i|
@@ -64,12 +68,6 @@ module SassC
     def error(message)
       $stderr.puts "[SassC::FunctionsHandler] #{message}"
       Native.make_error(message)
-    end
-
-    class FunctionWrapper
-      class << self
-        attr_accessor :options
-      end
     end
   end
 end


### PR DESCRIPTION
fixes https://github.com/rails/sprockets/issues/581 https://github.com/sass/sassc-rails/issues/121

I think there should be a better way to define custom functions, but unfortunatelly that would require changes in the API.

sprockets redefines functions which is super hacky
https://github.com/rails/sprockets/blob/1bcee8ebc03489eb7e42ee5c258a712443a6df3c/lib/sprockets/sassc_processor.rb#L58
https://github.com/rails/sprockets/blob/0cb3314368f9f9e84343ebedcc09c7137e920bc4/lib/sprockets/utils.rb#L126