### PR TITLE
Install bundler in Docker for `rake gem:native`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task 'gem:native' do
   # Only one version should be specified, as the shared library is Ruby-agnostic.
   #
   # g++-multilib is installed for 64->32-bit cross-compilation.
-  RakeCompilerDock.sh "sudo apt-get install -y g++-multilib && bundle && gem i rake --no-document && "\
+  RakeCompilerDock.sh "sudo apt-get install -y g++-multilib && gem i rake bundler --no-document && bundle && "\
                       "rake clean && rake cross native gem MAKE='nice make -j`nproc`' "\
                       "RUBY_CC_VERSION=2.6.0 CLEAN=1"
 end


### PR DESCRIPTION
Looks like it is no longer pre-installed by default.