### PR TITLE
Do not build precompiled gems for Linux

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ Rake::ExtensionTask.new('libsass', gem_spec) do |ext|
   ext.ext_dir = 'ext'
   ext.lib_dir = 'lib/sassc'
   ext.cross_compile = true
-  ext.cross_platform = %w[x86-mingw32 x64-mingw32 x86-linux x86_64-linux]
+  ext.cross_platform = %w[x86-mingw32 x64-mingw32]
 
   # Link C++ stdlib statically when building binary gems.
   ext.cross_config_options << '--enable-static-stdlib'


### PR DESCRIPTION
We can't target a particular libc with RubyGems and many users aren't aware of this (https://github.com/sass/sassc-ruby/issues/141).