### PR TITLE
Set appropriate encoding for source_map

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -57,6 +57,7 @@ module SassC
       Native.delete_data_context(data_context)
 
       css.force_encoding(@template.encoding)
+      @source_map.force_encoding(@template.encoding)
 
       return css unless quiet?
     end

--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -57,7 +57,7 @@ module SassC
       Native.delete_data_context(data_context)
 
       css.force_encoding(@template.encoding)
-      @source_map.force_encoding(@template.encoding)
+      @source_map.force_encoding(@template.encoding) if @source_map.is_a?(String)
 
       return css unless quiet?
     end


### PR DESCRIPTION
Set appropriate encoding for the string `@source_map` of `Engine`, similarly to that of the string `css` in `Engine#render`.

This PR will fix the error in the last line of the following code:

```ruby
# coding: utf-8
require "sassc"

template = <<EOS
body {
  // 赤
  color: red;
}
EOS
options = {
  :source_map_file => "foo.css.map",
  :source_map_contents => true
}
engine = SassC::Engine.new(template, options)
engine.render
source_map = engine.source_map
puts source_map             # includes non-ASCII character "赤"
puts source_map.encoding    # => ASCII-8BIT (UTF-8 is expected)
source_map.encode("UTF-8")  # throws Encoding::UndefinedConversionError
```
