### PR TITLE
Fix LoadError on some non-rvm environments

### DIFF
--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -7,7 +7,11 @@ module SassC
     extend FFI::Library
 
     dl_ext = (RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'bundle' : 'so')
-    ffi_lib File.expand_path("libsass.#{dl_ext}", __dir__)
+    begin
+      ffi_lib File.expand_path("libsass.#{dl_ext}", __dir__)
+    rescue LoadError # Some non-rvm environments don't copy a shared object over to lib/sassc
+      ffi_lib File.expand_path("libsass.#{dl_ext}", "#{__dir__}/../../ext")
+    end
 
     require_relative "native/sass_value"
 


### PR DESCRIPTION
Fixes sass/sassc-ruby#146. See also opal/c_lexer#1 for some discussion on the issue.