### PR TITLE
Color functions broken

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -310,5 +310,14 @@ CSS
       output = Engine.new("@import 'test'").render
       assert_equal expected_output, output
     end
+
+    def test_color_functions
+      expected_output = <<-CSS
+a {
+  color: #aabbcc; }
+  CSS
+      output = Engine.new('a { color: lighten(#abc, 0%); }').render
+      assert_equal expected_output, output
+    end
   end
 end


### PR DESCRIPTION
I was able to reproduce #151 using Docker. I added a test case that simply renders `a { color: lighten(#abc, 0%); }`.

The test is successfull on Ubuntu 14.04 64-bit using this Dockerfile:

```Dockerfile
FROM ubuntu:14.04
RUN apt-get update -q && apt-get install build-essential git software-properties-common -y
RUN apt-add-repository ppa:brightbox/ruby-ng
RUN apt-get update -q && apt-get install ruby2.3 ruby2.3-dev -y
ADD . /sassc-ruby
WORKDIR /sassc-ruby
RUN gem install bundler
RUN bundle install
RUN rake test
```

But on 14.04 32-bit using this Dockerfile, it fails:

```Dockerfile
FROM i386/ubuntu:14.04
RUN apt-get update -q && apt-get install build-essential git software-properties-common -y
RUN apt-add-repository ppa:brightbox/ruby-ng
RUN apt-get update -q && apt-get install ruby2.3 ruby2.3-dev -y
ADD . /sassc-ruby
WORKDIR /sassc-ruby
RUN gem install bundler
RUN bundle install
RUN rake test
```

Output:

```diff
SassC::EngineTest#test_color_functions [/sassc-ruby/test/engine_test.rb:320]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 "a {
-  color: #aabbcc; }
+  color: #ccaaaa; }
 "
```

Any ideas?