### PR TITLE
Default --march-tune-native to false

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -19,8 +19,7 @@ if enable_config('static-stdlib', false)
   $LDFLAGS << ' -static-libgcc -static-libstdc++'
 end
 
-# Set to false when building binary gems
-if enable_config('march-tune-native', true)
+if enable_config('march-tune-native', false)
   $CFLAGS << ' -march=native -mtune=native'
   $CXXFLAGS << ' -march=native -mtune=native'
 end


### PR DESCRIPTION
Despite the warnings, people still build using a different environment than the deployment one.
This change doesn't actually make the built library portable, just less likely to crash on a different CPU.

Refs #146