### PR TITLE
allow passing functions directly

### DIFF
--- a/lib/sassc/engine.rb
+++ b/lib/sassc/engine.rb
@@ -16,6 +16,7 @@ module SassC
     def initialize(template, options = {})
       @template = template
       @options = options
+      @functions = options.fetch(:functions, Script::Functions)
     end
 
     def render
@@ -37,7 +38,7 @@ module SassC
       Native.option_set_omit_source_map_url(native_options, true) if omit_source_map_url?
 
       import_handler.setup(native_options)
-      functions_handler.setup(native_options)
+      functions_handler.setup(native_options, functions: @functions)
 
       status = Native.compile_data_context(data_context)
 

--- a/lib/sassc/script.rb
+++ b/lib/sassc/script.rb
@@ -3,12 +3,12 @@
 module SassC
   module Script
 
-    def self.custom_functions
-      Functions.public_instance_methods
+    def self.custom_functions(functions: Functions)
+      functions.public_instance_methods
     end
 
-    def self.formatted_function_name(function_name)
-      params = Functions.instance_method(function_name).parameters
+    def self.formatted_function_name(function_name, functions: Functions)
+      params = functions.instance_method(function_name).parameters
       params = params.map { |param_type, name| "$#{name}#{': null' if param_type == :opt}" }.join(", ")
       return "#{function_name}(#{params})"
     end

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -201,6 +201,17 @@ module SassC
       end
     end
 
+    def test_pass_custom_functions_as_a_parameter
+      out = Engine.new("div { url: test-function(); }", {functions: ExternalFunctions}).render
+      assert_match /custom_function/, out
+    end
+
+    def test_pass_incompatible_type_to_custom_functions
+      assert_raises(TypeError) do
+        Engine.new("div { url: test-function(); }", {functions: Class.new}).render
+      end
+    end
+
     private
 
     def assert_sass(sass, expected_css)
@@ -317,6 +328,12 @@ module SassC
         SassC::Script::Value::List.new(numbers, separator: :space)
       end
 
+    end
+
+    module ExternalFunctions
+      def test_function
+        SassC::Script::Value::String.new("custom_function", :string)
+      end
     end
 
   end


### PR DESCRIPTION
my intention is to fix thread safety problems https://github.com/sass/sassc-ruby/issues/133 and https://github.com/rails/sprockets/issues/581
and eventually remove
https://github.com/rails/sprockets/blob/0cb3314368f9f9e84343ebedcc09c7137e920bc4/lib/sprockets/utils.rb#L126

sassc doesn't allow you to use different functions for different contexts easily

you can customize functions by patching `Sassc::Script::Functions`, but there's a race condition if you do this at runtime

this patch will allow you to pass custom functions like this
```
module MyModule
  def asset_path(path, _options = {})
  end
end

SassC::Engine.new(sass, style: :compressed).render # default Sassc::Script::Functions
SassC::Engine.new(sass, style: :compressed, functions: MyModule).render # custom
```

what do you think?
