### PR TITLE
disable lto flag for darwin + nix

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -25,7 +25,12 @@ if enable_config('march-tune-native', true)
   $CXXFLAGS << ' -march=native -mtune=native'
 end
 
-if enable_config('lto', true)
+# darwin nix clang doesn't support lto
+# disable -lto flag for darwin + nix
+# see: https://github.com/sass/sassc-ruby/issues/148
+enable_lto_by_default = (Gem::Platform.local.os == "darwin" && !ENV['NIX_CC'].nil?)
+
+if enable_config('lto', enable_lto_by_default)
   $CFLAGS << ' -flto'
   $CXXFLAGS << ' -flto'
   $LDFLAGS << ' -flto'


### PR DESCRIPTION
darwin nix's clang doesn't support -lto

this PR disables -lto flag for darwin + nix

see https://github.com/sass/sassc-ruby/issues/148 for more context