### PR TITLE
Test on TruffleRuby in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - truffleruby
 notifications:
   email: false


### PR DESCRIPTION
* To ensure `sassc` keeps working on TruffleRuby.
For instance `sassc` broke on TruffleRuby when switching to `mkmf` (https://github.com/sass/sassc-ruby/pull/127) but now works again (https://github.com/oracle/truffleruby/issues/1753).