### PR TITLE
Use RbConfig::MAKEFILE_CONFIG['DLEXT'] instead of hardcoding extensions

### DIFF
--- a/lib/sassc/native.rb
+++ b/lib/sassc/native.rb
@@ -6,7 +6,7 @@ module SassC
   module Native
     extend FFI::Library
 
-    dl_ext = (RbConfig::CONFIG['host_os'] =~ /darwin/ ? 'bundle' : 'so')
+    dl_ext = RbConfig::MAKEFILE_CONFIG['DLEXT']
     begin
       ffi_lib File.expand_path("libsass.#{dl_ext}", __dir__)
     rescue LoadError # Some non-rvm environments don't copy a shared object over to lib/sassc


### PR DESCRIPTION
* Since libsass is meant to be used with FFI, `RbConfig::CONFIG['SOEXT']`
  would be better, but DLEXT is used as libsass is compiled by mkmf (#127).
* Use `RbConfig::MAKEFILE_CONFIG['DLEXT']` instead of just `RbConfig::CONFIG['DLEXT']`
  so it's also correct on JRuby and not 'jar'. See
  https://github.com/rake-compiler/rake-compiler/blob/f808dd7a/lib/rake/extensiontask.rb#L41
* This lets Ruby implementations use another file extension than .so/.bundle
  for C extensions. For example, TruffleRuby 19.3.0 uses .dylib on macOS.
* Some OS also use a different file extension, such as HPUX which uses .sl.

This allows `sassc` to work again on TruffleRuby on macOS: https://github.com/oracle/truffleruby/issues/1819

cc @bolandrm @glebm 