### PR TITLE
Fix compile issue on Mac OS X

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -59,8 +59,6 @@ Dir.chdir(__dir__) do
   $srcs = Dir['libsass/src/**/*.{c,cpp}']
 end
 
-MakeMakefile::LINK_SO << "\nstrip -x $@"
-
 # Don't link libruby.
 $LIBRUBYARG = nil
 


### PR DESCRIPTION
Gem won't install on Mac OS X (Mohave) due to a compile error:

`libsass.bundle malformed object (unknown load command 7)`

This is in the code line which strips libsass.bundle of symbols. So this "fix" removes that command. I'm sure there's a better way, but this fixed the problem for me. Not sure why the bundle needs to be stripped or why Mac OS X has an issue with it.h