### PR TITLE
Sort input file list

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -56,7 +56,7 @@ $INCFLAGS << " -I$(srcdir)/libsass/include"
 $VPATH << "$(srcdir)/libsass/src"
 Dir.chdir(__dir__) do
   $VPATH += Dir['libsass/src/*/'].map { |p| "$(srcdir)/#{p}" }
-  $srcs = Dir['libsass/src/**/*.{c,cpp}']
+  $srcs = Dir['libsass/src/**/*.{c,cpp}'].sort
 end
 
 # Don't link libruby.


### PR DESCRIPTION
Sort input file list
so that `libsass.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.
Package is called `rubygem-sassc` there.

The only other problem is that `--disable-march-tune-native` is not the default, so results vary depending on build worker CPU. Could also be selected if the `SOURCE_DATE_EPOCH` env var is set.