### PR TITLE
Fix check to disable LTO by default

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -27,7 +27,7 @@ end
 # darwin nix clang doesn't support lto
 # disable -lto flag for darwin + nix
 # see: https://github.com/sass/sassc-ruby/issues/148
-enable_lto_by_default = (Gem::Platform.local.os == "darwin" && !ENV['NIX_CC'].nil?)
+enable_lto_by_default = (Gem::Platform.local.os == "darwin" && ENV['NIX_CC'].nil?)
 
 if enable_config('lto', enable_lto_by_default)
   $CFLAGS << ' -flto'


### PR DESCRIPTION
This got sassc-ruby working for me using Nix on Darwin.