### PR TITLE
Test against Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - 2.7.0
   - truffleruby
 notifications:
   email: false


### PR DESCRIPTION
This Pull Request adds `2.7.0` entry to `.travis.yml` since Ruby 2.7.0 was released a few months ago and it worth testing against.