### PR TITLE
Fix rake gem:native task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,9 +36,7 @@ task 'gem:native' do
 
   # The RUBY_CC_VERSION here doesn't matter for the final package.
   # Only one version should be specified, as the shared library is Ruby-agnostic.
-  #
-  # g++-multilib is installed for 64->32-bit cross-compilation.
-  RakeCompilerDock.sh "sudo apt-get install -y g++-multilib && gem i rake bundler --no-document && bundle && "\
+  RakeCompilerDock.sh "gem i rake bundler --no-document && bundle && "\
                       "rake clean && rake cross native gem MAKE='nice make -j`nproc`' "\
                       "RUBY_CC_VERSION=2.6.0 CLEAN=1"
 end


### PR DESCRIPTION
As discussed in https://github.com/sass/sassc-ruby/issues/195, `rake gem:native` is currently broken, preventing a new release.

The error is:

```
Package g++-multilib is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'g++-multilib' has no installation candidate
rake aborted!
```

I looked around and apparently this package is outdated an no longer available. However it's used for cross compiling for 32bit packages.

If we looked at downloaded packages:

  - https://rubygems.org/gems/sassc/versions/2.1.0-x86_64-linux 500K downloads
  - https://rubygems.org/gems/sassc/versions/2.1.0-x86-linux (32bits) 756 downloads.

I think it's safe to say that close to nobody downloads the 32 bits binaries, and for the few people who do, AFAIK it should fallback somewhat nicely to compiling from source.

All that to say that I think it's OK to drop it.

cc @bolandrm @rafaelfranca