### PR TITLE
Update README.md for libsass version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This gem combines the speed of `libsass`, the [Sass C implementation](https://gi
 
 ### libsass Version
 
-[3.6.1](https://github.com/sass/libsass/releases/3.6.1)
+[3.6.4](https://github.com/sass/libsass/releases/3.6.4)
 
 ## Installation
 


### PR DESCRIPTION
libsass was updated to v3.6.4 in sassc-ruby v2.4.0 via #199.