### PR TITLE
Build native extensions on M1

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -19,7 +19,9 @@ if enable_config('static-stdlib', false)
   $LDFLAGS << ' -static-libgcc -static-libstdc++'
 end
 
-if enable_config('march-tune-native', false)
+# darwin arm doesn't support native
+# see: https://github.com/sass/sassc-ruby/issues/222
+if enable_config('march-tune-native', false) && Gem::Platform.local.cpu != 'arm64'
   $CFLAGS << ' -march=native -mtune=native'
   $CXXFLAGS << ' -march=native -mtune=native'
 end


### PR DESCRIPTION
We already support disabling this compilation flag anyway, so might as well just do it automatically for architectures that don't support it.