### PR TITLE
fix a static build

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -16,7 +16,7 @@ $CXXFLAGS << ' -std=c++11'
 
 # Set to true when building binary gems
 if enable_config('static-stdlib', false)
-  $LDFLAGS << ' -static-libgcc -static-libstdc++'
+  $LDFLAGS << ' -static'
 end
 
 if enable_config('march-tune-native', false)


### PR DESCRIPTION
on Windows, ```LIBWINPTHREAD-1.DLL``` is still linked dynamically

a static build shouldn't depend on external libraries. Especially JRuby should be able to load the static library at runtime without a devkit environment. However, devkit tools are still necessary to build the library on JRuby. see https://github.com/sass/sassc-ruby/issues/182#issuecomment-857776845