### PR TITLE
Replace libsass with sassc-embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,24 @@
 # SassC [![Build Status](https://travis-ci.org/sass/sassc-ruby.svg?branch=master)](https://travis-ci.org/sass/sassc-ruby) [![Gem Version](https://badge.fury.io/rb/sassc.svg)](http://badge.fury.io/rb/sassc)
 
-Use `libsass` with Ruby!
+Use `sassc-embedded` with SassC Ruby!
 
-This gem combines the speed of `libsass`, the [Sass C implementation](https://github.com/sass/libsass), with the ease of use of the original [Ruby Sass](https://github.com/sass/ruby-sass) library.
+This fork removes the deprecated [`libsass`](https://github.com/sass/libsass) and replace it with [`sassc-embedded`](https://github.com/ntkme/sassc-embedded-polyfill-ruby), providing latest sass features and fast gem installation.
 
-### libsass Version
-
-[3.6.1](https://github.com/sass/libsass/releases/3.6.1)
+This should essentially be a drop in alternative to [sass/sassc-ruby](https://github.com/sass/sassc-ruby).
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add these lines to your application's Gemfile:
 
 ```ruby
-gem 'sassc'
+gem 'sassc', github: 'sass/sassc-ruby', ref: "refs/pull/233/head"
+gem 'sassc-embedded'
 ```
 
 And then execute:
 
 ```bash
 bundle
-```
-
-Or install it yourself as:
-
-```bash
-gem install sassc
 ```
 
 ## Usage
@@ -39,8 +32,6 @@ SassC::Engine.new(sass, style: :compressed).render
 
 **Note**:  If you want to use this library with Rails/Sprockets, check out
 [sassc-rails](https://github.com/bolandrm/sassc-rails).
-
-Additionally, you can use `SassC::Sass2Scss` to convert Sass syntax to Scss syntax.
 
 ## Credits
 

--- a/lib/sassc.rb
+++ b/lib/sassc.rb
@@ -28,7 +28,7 @@ module SassC
 end
 
 require_relative "sassc/version"
-require_relative "sassc/native"
+# require_relative "sassc/native"
 require_relative "sassc/import_handler"
 require_relative "sassc/importer"
 require_relative "sassc/util"
@@ -42,16 +42,23 @@ require_relative "sassc/script/value/string"
 require_relative "sassc/script/value/list"
 require_relative "sassc/script/value/map"
 require_relative "sassc/script/functions"
-require_relative "sassc/script/value_conversion"
-require_relative "sassc/script/value_conversion/base"
-require_relative "sassc/script/value_conversion/string"
-require_relative "sassc/script/value_conversion/number"
-require_relative "sassc/script/value_conversion/color"
-require_relative "sassc/script/value_conversion/map"
-require_relative "sassc/script/value_conversion/list"
-require_relative "sassc/script/value_conversion/bool"
+# require_relative "sassc/script/value_conversion"
+# require_relative "sassc/script/value_conversion/base"
+# require_relative "sassc/script/value_conversion/string"
+# require_relative "sassc/script/value_conversion/number"
+# require_relative "sassc/script/value_conversion/color"
+# require_relative "sassc/script/value_conversion/map"
+# require_relative "sassc/script/value_conversion/list"
+# require_relative "sassc/script/value_conversion/bool"
 require_relative "sassc/functions_handler"
 require_relative "sassc/dependency"
 require_relative "sassc/error"
 require_relative "sassc/engine"
-require_relative "sassc/sass_2_scss"
+# require_relative "sassc/sass_2_scss"
+
+begin
+  old_verbose, $VERBOSE = $VERBOSE, nil
+  require 'sassc-embedded'
+ensure
+  $VERBOSE = old_verbose
+end

--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.platform      = Gem::Platform::RUBY
-  spec.extensions    = ["ext/extconf.rb"]
+  # spec.extensions    = ["ext/extconf.rb"]
 
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "minitest-around"
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "rake-compiler-dock"
 
+=begin
   spec.add_dependency "ffi", "~> 1.9"
 
   gem_dir = File.expand_path(File.dirname(__FILE__)) + "/"
@@ -65,5 +66,6 @@ Gem::Specification.new do |spec|
     end
     spec.files << File.join(submodule_relative_path, 'VERSION')
   end
+=end
 
 end


### PR DESCRIPTION
This PR removes the deprecated [`libsass`](https://github.com/sass/libsass) and replace it with [`sassc-embedded`](https://github.com/ntkme/sassc-embedded-polyfill-ruby), providing latest sass features and fast gem installation.

This should essentially be a drop in alternative to current sassc-ruby.

---

## Installation

Add these lines to your application's Gemfile:

```ruby
gem 'sassc', github: 'sass/sassc-ruby', ref: 'refs/pull/233/head'
gem 'sassc-embedded'
```

And then execute:
```bash
bundle
```