### PR TITLE
 Use Minitest module instead of MiniTest compatibility layer

### DIFF
--- a/sassc.gemspec
+++ b/sassc.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.platform      = Gem::Platform::RUBY
   spec.extensions    = ["ext/extconf.rb"]
 
-  spec.add_development_dependency "minitest", "~> 5.5.1"
+  spec.add_development_dependency "minitest", ">= 5.5.1", "< 5.20"
   spec.add_development_dependency "minitest-around"
   spec.add_development_dependency "test_construct"
   spec.add_development_dependency "pry"

--- a/test/custom_importer_test.rb
+++ b/test/custom_importer_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module SassC
-  class CustomImporterTest < MiniTest::Test
+  class CustomImporterTest < Minitest::Test
     include TempFileTest
 
     class CustomImporter < Importer

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module SassC
-  class EngineTest < MiniTest::Test
+  class EngineTest < Minitest::Test
     include TempFileTest
 
     def render(data)

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module SassC
-  class ErrorTest < MiniTest::Test
+  class ErrorTest < Minitest::Test
     def render(data, opts={})
       Engine.new(data, opts).render
     end

--- a/test/functions_test.rb
+++ b/test/functions_test.rb
@@ -4,7 +4,7 @@ require_relative "test_helper"
 require "stringio"
 
 module SassC
-  class FunctionsTest < MiniTest::Test
+  class FunctionsTest < Minitest::Test
     include FixtureHelper
 
     def setup

--- a/test/native_test.rb
+++ b/test/native_test.rb
@@ -9,13 +9,13 @@ module SassC
     SAMPLE_CSS_OUTPUT = ".hi {\n  width: 30px; }\n"
     BAD_SASS_STRING = "$size = 30px;"
 
-    class General < MiniTest::Test
+    class General < Minitest::Test
       def test_it_reports_the_libsass_version
         assert_equal "3.6.4", Native.version
       end
     end
 
-    class DataContext < MiniTest::Test
+    class DataContext < Minitest::Test
       def teardown
         Native.delete_data_context(@data_context) if @data_context
       end
@@ -105,7 +105,7 @@ module SassC
       end
     end
 
-    class FileContext < MiniTest::Test
+    class FileContext < Minitest::Test
       include TempFileTest
 
       def teardown

--- a/test/output_style_test.rb
+++ b/test/output_style_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module SassC
-  class OutputStyleTest < MiniTest::Test
+  class OutputStyleTest < Minitest::Test
     def input_scss
       input_scss = <<-CSS
 $color: #fff;

--- a/test/sass_2_scss_test.rb
+++ b/test/sass_2_scss_test.rb
@@ -3,7 +3,7 @@
 require_relative "test_helper"
 
 module SassC
-  class Sass2ScssTest < MiniTest::Test
+  class Sass2ScssTest < Minitest::Test
     def test_compact_output
       assert_equal ".blat { color: red; }", Sass2Scss.convert(<<SASS)
 .blat


### PR DESCRIPTION
The Minitest package has long been capitalized like that. The variant
MiniTest is retained only as a compatibility layer. Switch to the
current module name.

This change is motivated by Fedora, which already uses minitest 5.19.
That version requires setting the env variable MT_COMPAT to import the
compatibility module, and thus revealed the problem in Fedora build
system.