### PR TITLE
Test against new Ruby versions released since last update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rvm:
   - 2.5.5
   - 2.6.3
   - 2.7.0
+  - 3.0.6
+  - 3.1.4
+  - 3.2.2
+  - 3.3.0
   - truffleruby
 notifications:
   email: false


### PR DESCRIPTION
I'm having issues with sassc on Ruby 3.2 so I want to see if anything pops up in Travis.