### PR TITLE
Handle non-StandardError in custom functions

### DIFF
--- a/lib/sassc/functions_handler.rb
+++ b/lib/sassc/functions_handler.rb
@@ -25,7 +25,7 @@ module SassC
             function_arguments = arguments_from_native_list(native_argument_list)
             result = functions_wrapper.send(custom_function, *function_arguments)
             to_native_value(result)
-          rescue StandardError => exception
+          rescue Exception => exception
             # This rescues any exceptions that occur either in value conversion
             # or during the execution of a custom function.
             error(exception.message)


### PR DESCRIPTION
fixes #244

When exception that is not a subclass of `StandardError` happens inside custom sass function, it's not handled by `SassC::FunctionsHandler` and gets raised up to `FFI::Function` block body, where ffi gem silently catches it and treats as if block returned `nil`. This causes segmentation fault later in C code, when trying to dereference null pointer.

This changes `rescue` in `functions_handler` to handle all exceptions.

Recovering from non-`StandardError` might be not a good idea in general (for example when exception is `NoMemoryError`), but I didn't find proper ways to abort the whole process inside ffi callback. Tried `Kernel#abort`, it just prints error message and causes callback to return nil so the same segfault remains. Maybe using `abort()` libc function directly is an option but I doubt if it's portable enough between systems. So, I think, rescuing all exception is okay here.