### PR TITLE
Enable LTO by default on all platforms

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -24,12 +24,7 @@ if enable_config('march-tune-native', false)
   $CXXFLAGS << ' -march=native -mtune=native'
 end
 
-# darwin nix clang doesn't support lto
-# disable -lto flag for darwin + nix
-# see: https://github.com/sass/sassc-ruby/issues/148
-enable_lto_by_default = (Gem::Platform.local.os == "darwin" && ENV['NIX_CC'].nil?)
-
-if enable_config('lto', enable_lto_by_default)
+if enable_config('lto', true)
   $CFLAGS << ' -flto'
   $CXXFLAGS << ' -flto'
   $LDFLAGS << ' -flto'


### PR DESCRIPTION
The [old comment by @lrworth](https://github.com/sass/sassc-ruby/pull/192#discussion_r423959519) was spot on, but ended up drowning under further discussion, which led to LTO being enabled only on Darwin by default except in Nix. While my prime motivation was sorting it out for Nix, I ended up spotting the error for all platforms. :shrug: 